### PR TITLE
<Hui> added logger auto-tracker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,14 @@
 			<artifactId>selenium-java</artifactId>
 			<version>4.11.0</version>
 		</dependency>
+
+		<!--
+		https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-http-jdk-client -->
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-http-jdk-client</artifactId>
+			<version>4.11.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This new maven dependency would take care of all remote communcations. 
If you set:
`System.setProperty("webdriver.http.factory", "jdk-http-client");`
Before WebDriver object.
You won't see any red logger that you would normally see in your concole.